### PR TITLE
fix(core): broken tests

### DIFF
--- a/projects/core/src/test/directive/component.outlet.lifecycle.spec.ts
+++ b/projects/core/src/test/directive/component.outlet.lifecycle.spec.ts
@@ -262,9 +262,10 @@ function makeTestWithComponent(componentType: Type<any>, component: Type<any>) {
         builder.operation([
             builder.changeInput('label', FRAMEWORK)
         ]),
-        builder.operation([]),
         builder.operation([
-            builder.resetComponent(),
+            builder.resetComponent()
+        ]),
+        builder.operation([
             builder.resetInput('name'),
             builder.resetInput('label')
         ]),


### PR DESCRIPTION
Tests fail for `onDestroy` in `FullLifecycleDynamicComponent`.
Reset of a component is grouped with resets of inputs. Change of bound inputs appears immediately, but dispose of the component will be in `ngOnChanges` of the directive.  Because of it, the component will be destroyed after inputs will be reset.